### PR TITLE
Add MQTT scene metadata and local room cleaning support

### DIFF
--- a/build/cjs/controllers/LocalConnect.js
+++ b/build/cjs/controllers/LocalConnect.js
@@ -1,15 +1,17 @@
 "use strict";
-// Communication with the Local Tuya API
-// This is only supported for "old" devices like the RoboVac G30
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.LocalConnect = void 0;
-// As of july 2024 this is not used in the main codebase, but it's here for reference
 const utils_1 = require("../lib/utils");
 const SharedConnect_1 = require("./SharedConnect");
 const tuyapi_1 = __importDefault(require("tuyapi"));
+const PROBE_DPS = [
+    2, 5, 15, 101, 103, 104, 106, 109, 110, 111, 116, 117, 124, 125, 126, 135, 142,
+    151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163,
+    164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180
+];
 class LocalConnect extends SharedConnect_1.SharedConnect {
     api;
     didCheckApiType;
@@ -21,6 +23,7 @@ class LocalConnect extends SharedConnect_1.SharedConnect {
         this.config = config;
         this.debugLog = config.debug || false;
         this.didCheckApiType = false;
+        this.connected = false;
     }
     async setupApi(config) {
         this.api = new tuyapi_1.default({
@@ -28,7 +31,8 @@ class LocalConnect extends SharedConnect_1.SharedConnect {
             key: config.localKey,
             ip: config.ip,
             port: 6668,
-            version: '3.3'
+            version: config.version || '3.3',
+            issueRefreshOnConnect: true
         });
         this.api.on('error', (error) => {
             console.error('Robovac Error', error);
@@ -58,25 +62,24 @@ class LocalConnect extends SharedConnect_1.SharedConnect {
     async connect() {
         if (!this.connected) {
             await this.setupApi(this.config);
-            await (0, utils_1.sleep)(2000);
+            await (0, utils_1.sleep)(500);
             console.log('Connecting...');
-            await this.api.connect().catch(error => {
-                console.log(error);
-                console.error(`Failed to connect to device please close the app or check your network. Please allow port 6668 via TCP from the device IP. ${error}`);
-            });
+            await this.connectWithFallback();
         }
-        await this.api.refresh({ schema: true });
+        await this.refreshDeviceState();
         setTimeout(() => {
             this.formatStatus();
         }, 2000);
     }
     async disconnect() {
         console.log('Disconnecting...');
-        await this.api.disconnect();
+        if (this.api) {
+            await this.api.disconnect();
+        }
     }
     async updateDevice() {
         try {
-            await this.api?.refresh({ schema: true });
+            await this.refreshDeviceState();
         }
         catch (error) {
             console.log(error);
@@ -90,6 +93,54 @@ class LocalConnect extends SharedConnect_1.SharedConnect {
             multiple: true,
             data: data
         });
+    }
+    getResolvedIp() {
+        return this.api?.device?.ip || this.config?.ip;
+    }
+    async connectWithFallback() {
+        try {
+            if (!this.config.ip) {
+                await this.findDevice();
+            }
+            await this.api.connect();
+            this.config.ip = this.getResolvedIp() || this.config.ip;
+        }
+        catch (error) {
+            if (!this.config.ip) {
+                throw error;
+            }
+            console.warn('Direct local connection failed, retrying with discovery.', error);
+            this.connected = false;
+            await this.findDevice(true);
+            await this.api.connect();
+            this.config.ip = this.getResolvedIp() || this.config.ip;
+        }
+    }
+    async findDevice(force = false) {
+        if (force) {
+            this.api.device && (this.api.device.ip = undefined);
+            this.config.ip = undefined;
+        }
+        const foundDevice = await this.api.find({
+            timeout: this.config.findTimeoutSeconds || 10
+        });
+        const resolvedIp = foundDevice?.ip || this.api?.device?.ip;
+        if (resolvedIp) {
+            this.config.ip = resolvedIp;
+        }
+    }
+    async refreshDeviceState() {
+        const basePayload = await this.api?.get({ schema: true }).catch(() => undefined);
+        if (basePayload?.dps) {
+            await this.onUpdate(basePayload.dps);
+        }
+        const refreshPayload = await this.api?.refresh({
+            schema: true,
+            requestedDPS: PROBE_DPS
+        }).catch(() => undefined);
+        if (refreshPayload?.dps) {
+            await this.onUpdate(refreshPayload.dps);
+        }
     }
 }
 exports.LocalConnect = LocalConnect;

--- a/build/cjs/controllers/Login.js
+++ b/build/cjs/controllers/Login.js
@@ -76,6 +76,9 @@ class EufyLogin extends Base_1.Base {
                 this.cloudDevices = await this.tuyaApi.getDeviceList();
                 this.cloudDevices = this.cloudDevices.map(device => ({
                     ...this.findModel(device.devId),
+                    localKey: device.localKey,
+                    productId: device.productId,
+                    ip: device.ip,
                     apiType: this.checkApiType(device.dps),
                     mqtt: false,
                     dps: device?.dps || {}

--- a/build/cjs/controllers/SharedConnect.js
+++ b/build/cjs/controllers/SharedConnect.js
@@ -5,18 +5,22 @@ const Base_1 = require("./Base");
 const state_constants_1 = require("../constants/state.constants");
 const devices_constants_1 = require("../constants/devices.constants");
 const utils_1 = require("../lib/utils");
+const LOCAL_NOVEL_FALLBACK_DPS = ['151', '156', '158', '159', '160', '161', '163', '177'];
 class SharedConnect extends Base_1.Base {
     novelApi = false;
     robovacData = {};
+    rawDps = {};
     debugLog;
     deviceId;
     deviceModel;
     config = {};
+    seq;
     constructor(config) {
         super();
         this.deviceId = config.deviceId;
         this.deviceModel = config.deviceModel || '';
         this.debugLog = config.debug || false;
+        this.seq = Math.floor(Date.now() % 1000);
     }
     async checkApiType(dps) {
         try {
@@ -24,7 +28,7 @@ class SharedConnect extends Base_1.Base {
                 console.log('Novel API detected');
                 this.setApiTypes(true);
             }
-            else {
+            else if (!this.novelApi) {
                 console.log('Legacy API detected');
                 this.setApiTypes(false);
             }
@@ -36,9 +40,10 @@ class SharedConnect extends Base_1.Base {
     async setApiTypes(novelApi) {
         this.novelApi = novelApi;
         this.DPSMap = this.novelApi ? this.novelDPSMap : this.legacyDPSMap;
-        this.robovacData = { ...this.DPSMap }; // Make shallow copy of DPSMap
+        this.robovacData = { ...this.DPSMap };
     }
     mapData(dps) {
+        this.rawDps = { ...this.rawDps, ...(dps || {}) };
         for (const key in dps) {
             const mappedKeys = Object.keys(this.DPSMap).filter(k => this.DPSMap[k] === key);
             if (mappedKeys.length) {
@@ -54,6 +59,33 @@ class SharedConnect extends Base_1.Base {
     async getRobovacData() {
         return this.robovacData;
     }
+    async listScenes() {
+        const raw = this.rawDps['180'] || this.robovacData?.SCENES;
+        if (typeof raw !== 'string') {
+            return [];
+        }
+        try {
+            const value = await (0, utils_1.decode)('./proto/cloud/scene.proto', 'SceneResponse', raw);
+            const infos = Array.isArray(value?.infos) ? value.infos : [];
+            return infos
+                .map((info) => ({
+                id: Number(info?.id?.value ?? 0),
+                name: String(info?.name ?? '').trim(),
+                mapId: info?.mapid ? Number(info.mapid) : undefined
+            }))
+                .filter((scene) => scene.id > 0 && scene.name);
+        }
+        catch (error) {
+            console.error(error);
+            return [];
+        }
+    }
+    supportsNamedScenes() {
+        return !!this.config?.mqtt;
+    }
+    supportsNumericRoomClean() {
+        return !!this.config?.localKey && (this.novelApi || this.canUseMappedLocalFallback());
+    }
     async getCleanSpeed() {
         if (typeof this.robovacData?.CLEAN_SPEED === 'number' || this.robovacData?.CLEAN_SPEED?.length === 1) {
             const cleanSpeeds = Object.values(state_constants_1.EUFY_CLEAN_NOVEL_CLEAN_SPEED);
@@ -64,7 +96,6 @@ class SharedConnect extends Base_1.Base {
     async getControlResponse() {
         try {
             if (this.novelApi) {
-                //BAgNEH0=
                 const value = await (0, utils_1.decode)('./proto/cloud/control.proto', 'ModeCtrlResponse', 'AhB8');
                 return value || {};
             }
@@ -166,83 +197,84 @@ class SharedConnect extends Base_1.Base {
         }
     }
     async autoClean() {
-        let value = true;
-        if (this.novelApi) {
-            value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: state_constants_1.EUFY_CLEAN_CONTROL.START_AUTO_CLEAN,
                 autoClean: {
                     cleanTimes: 1
                 }
             });
-            return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value });
         }
         await this.sendCommand({ [this.DPSMap.WORK_MODE]: state_constants_1.EUFY_CLEAN_WORK_MODE.AUTO });
         return await this.play();
     }
     async sceneClean(id) {
-        await this.stop();
-        let value = true;
-        let increment = 3; // Scene 1 is 4, Scene 2 is 5, Scene 3 is 6 etc.
-        if (this.novelApi) {
-            value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.supportsNamedScenes()) {
+            return await this.sendNovelControlCommand({
                 method: state_constants_1.EUFY_CLEAN_CONTROL.START_SCENE_CLEAN,
                 sceneClean: {
-                    sceneId: id + increment
+                    sceneId: id
                 }
             });
         }
-        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value });
+        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: true });
+    }
+    async sceneCleanSlot(slot) {
+        if (this.novelApi || this.supportsNamedScenes()) {
+            return await this.sendNovelControlCommand({
+                method: state_constants_1.EUFY_CLEAN_CONTROL.START_SCENE_CLEAN,
+                sceneClean: {
+                    sceneId: slot + 3
+                }
+            });
+        }
+        return await this.sceneClean(slot);
     }
     async play() {
         let value = true;
-        if (this.novelApi) {
-            value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: state_constants_1.EUFY_CLEAN_CONTROL.RESUME_TASK
             });
         }
         return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value });
     }
     async pause() {
-        let value = false;
-        if (this.novelApi) {
-            value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: state_constants_1.EUFY_CLEAN_CONTROL.PAUSE_TASK
             });
         }
-        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value });
+        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: false });
     }
     async stop() {
-        let value = false;
-        if (this.novelApi) {
-            value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: state_constants_1.EUFY_CLEAN_CONTROL.STOP_TASK
             });
         }
-        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value });
+        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: false });
     }
     async goHome() {
-        if (this.novelApi) {
-            const value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: state_constants_1.EUFY_CLEAN_CONTROL.START_GOHOME
             });
-            return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value });
         }
         return await this.sendCommand({ [this.DPSMap.GO_HOME]: true });
     }
     async spotClean() {
-        if (this.novelApi) {
-            const value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: state_constants_1.EUFY_CLEAN_CONTROL.START_SPOT_CLEAN
             });
-            return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value });
         }
     }
     async roomClean() {
-        if (this.novelApi) {
-            const value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseMappedLocalFallback()) {
+            return await this.sendNovelControlCommand({
                 method: state_constants_1.EUFY_CLEAN_CONTROL.START_SELECT_ROOMS_CLEAN
             });
-            return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value });
         }
         if (devices_constants_1.EUFY_CLEAN_X_SERIES.includes(this.deviceModel) || devices_constants_1.EUFY_CLEAN_E_SERIES.includes(this.deviceModel)) {
             await this.sendCommand({ [this.DPSMap.WORK_MODE]: state_constants_1.EUFY_CLEAN_WORK_MODE.SMALL_ROOM });
@@ -250,6 +282,29 @@ class SharedConnect extends Base_1.Base {
         }
         await this.sendCommand({ [this.DPSMap.WORK_MODE]: state_constants_1.EUFY_CLEAN_WORK_MODE.ROOM });
         return await this.play();
+    }
+    async cleanRooms(roomIds, cleanTimes = 1) {
+        const normalizedRoomIds = roomIds
+            .map((roomId) => Number.parseInt(String(roomId), 10))
+            .filter((roomId) => Number.isFinite(roomId) && roomId > 0);
+        if (!normalizedRoomIds.length) {
+            throw new Error('Please provide at least one valid room ID.');
+        }
+        if (this.novelApi || this.canUseMappedLocalFallback()) {
+            const mapId = Number(this.config?.mapId || 0);
+            return await this.sendNovelControlCommand({
+                method: state_constants_1.EUFY_CLEAN_CONTROL.START_SELECT_ROOMS_CLEAN,
+                selectRoomsClean: {
+                    rooms: normalizedRoomIds.map((id, index) => ({
+                        id,
+                        order: index + 1
+                    })),
+                    cleanTimes: cleanTimes > 0 ? cleanTimes : 1,
+                    ...(mapId > 0 ? { mapId } : {})
+                }
+            });
+        }
+        return await this.roomClean();
     }
     async setCleanParam(config) {
         if (!this.novelApi)
@@ -279,6 +334,30 @@ class SharedConnect extends Base_1.Base {
     }
     async sendCommand(data) {
         throw new Error('Method not implemented.');
+    }
+    nextSeq() {
+        this.seq = (this.seq % 65535) + 1;
+        return this.seq;
+    }
+    hasNovelLocalControlSignals() {
+        return !!this.config?.localKey && Object.keys(this.rawDps).some((key) => LOCAL_NOVEL_FALLBACK_DPS.includes(key));
+    }
+    canUseLocalNovelControlFallback() {
+        return !this.novelApi && this.hasNovelLocalControlSignals();
+    }
+    canUseMappedLocalFallback() {
+        const mapId = Number(this.config?.mapId || 0);
+        return this.canUseLocalNovelControlFallback() && mapId > 0;
+    }
+    getNovelControlDp() {
+        return this.novelApi ? this.DPSMap.PLAY_PAUSE : this.novelDPSMap.PLAY_PAUSE;
+    }
+    async sendNovelControlCommand(command) {
+        const value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+            seq: this.nextSeq(),
+            ...command
+        });
+        return await this.sendCommand({ [this.getNovelControlDp()]: value });
     }
 }
 exports.SharedConnect = SharedConnect;

--- a/build/cjs/index.js
+++ b/build/cjs/index.js
@@ -56,8 +56,7 @@ class EufyClean {
         return [...this.eufyCleanApi.cloudDevices, ...this.eufyCleanApi.mqttDevices];
     }
     async initDevice(deviceConfig) {
-        if ('localKey' in deviceConfig && 'ip' in deviceConfig && deviceConfig.localKey) {
-            console.log('LocalConnect is deprecated, use CloudConnect instead');
+        if ('localKey' in deviceConfig && deviceConfig.localKey) {
             return new LocalConnect_1.LocalConnect(deviceConfig);
         }
         // Local connection doesn't require this check

--- a/build/cjs/lib/utils.js
+++ b/build/cjs/lib/utils.js
@@ -37,8 +37,8 @@ exports.decode = decode;
 const encode = async function (proto, type, object) {
     const root = await (0, exports.getProtoFile)(proto);
     const protoLookupType = root.lookupType(type);
-    // Create a new message from the object
-    const message = protoLookupType.create(object);
+    // Convert plain objects so enum/string fields are mapped correctly.
+    const message = protoLookupType.fromObject(object);
     // Encode the message to a buffer using encodeDelimited
     const buffer = protoLookupType.encodeDelimited(message).finish();
     // Convert the buffer to a base64 string

--- a/build/esm/controllers/LocalConnect.js
+++ b/build/esm/controllers/LocalConnect.js
@@ -1,15 +1,17 @@
 "use strict";
-// Communication with the Local Tuya API
-// This is only supported for "old" devices like the RoboVac G30
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.LocalConnect = void 0;
-// As of july 2024 this is not used in the main codebase, but it's here for reference
 const utils_1 = require("../lib/utils");
 const SharedConnect_1 = require("./SharedConnect");
 const tuyapi_1 = __importDefault(require("tuyapi"));
+const PROBE_DPS = [
+    2, 5, 15, 101, 103, 104, 106, 109, 110, 111, 116, 117, 124, 125, 126, 135, 142,
+    151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163,
+    164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180
+];
 class LocalConnect extends SharedConnect_1.SharedConnect {
     api;
     didCheckApiType;
@@ -21,6 +23,7 @@ class LocalConnect extends SharedConnect_1.SharedConnect {
         this.config = config;
         this.debugLog = config.debug || false;
         this.didCheckApiType = false;
+        this.connected = false;
     }
     async setupApi(config) {
         this.api = new tuyapi_1.default({
@@ -28,7 +31,8 @@ class LocalConnect extends SharedConnect_1.SharedConnect {
             key: config.localKey,
             ip: config.ip,
             port: 6668,
-            version: '3.3'
+            version: config.version || '3.3',
+            issueRefreshOnConnect: true
         });
         this.api.on('error', (error) => {
             console.error('Robovac Error', error);
@@ -58,25 +62,24 @@ class LocalConnect extends SharedConnect_1.SharedConnect {
     async connect() {
         if (!this.connected) {
             await this.setupApi(this.config);
-            await (0, utils_1.sleep)(2000);
+            await (0, utils_1.sleep)(500);
             console.log('Connecting...');
-            await this.api.connect().catch(error => {
-                console.log(error);
-                console.error(`Failed to connect to device please close the app or check your network. Please allow port 6668 via TCP from the device IP. ${error}`);
-            });
+            await this.connectWithFallback();
         }
-        await this.api.refresh({ schema: true });
+        await this.refreshDeviceState();
         setTimeout(() => {
             this.formatStatus();
         }, 2000);
     }
     async disconnect() {
         console.log('Disconnecting...');
-        await this.api.disconnect();
+        if (this.api) {
+            await this.api.disconnect();
+        }
     }
     async updateDevice() {
         try {
-            await this.api?.refresh({ schema: true });
+            await this.refreshDeviceState();
         }
         catch (error) {
             console.log(error);
@@ -90,6 +93,54 @@ class LocalConnect extends SharedConnect_1.SharedConnect {
             multiple: true,
             data: data
         });
+    }
+    getResolvedIp() {
+        return this.api?.device?.ip || this.config?.ip;
+    }
+    async connectWithFallback() {
+        try {
+            if (!this.config.ip) {
+                await this.findDevice();
+            }
+            await this.api.connect();
+            this.config.ip = this.getResolvedIp() || this.config.ip;
+        }
+        catch (error) {
+            if (!this.config.ip) {
+                throw error;
+            }
+            console.warn('Direct local connection failed, retrying with discovery.', error);
+            this.connected = false;
+            await this.findDevice(true);
+            await this.api.connect();
+            this.config.ip = this.getResolvedIp() || this.config.ip;
+        }
+    }
+    async findDevice(force = false) {
+        if (force) {
+            this.api.device && (this.api.device.ip = undefined);
+            this.config.ip = undefined;
+        }
+        const foundDevice = await this.api.find({
+            timeout: this.config.findTimeoutSeconds || 10
+        });
+        const resolvedIp = foundDevice?.ip || this.api?.device?.ip;
+        if (resolvedIp) {
+            this.config.ip = resolvedIp;
+        }
+    }
+    async refreshDeviceState() {
+        const basePayload = await this.api?.get({ schema: true }).catch(() => undefined);
+        if (basePayload?.dps) {
+            await this.onUpdate(basePayload.dps);
+        }
+        const refreshPayload = await this.api?.refresh({
+            schema: true,
+            requestedDPS: PROBE_DPS
+        }).catch(() => undefined);
+        if (refreshPayload?.dps) {
+            await this.onUpdate(refreshPayload.dps);
+        }
     }
 }
 exports.LocalConnect = LocalConnect;

--- a/build/esm/controllers/Login.js
+++ b/build/esm/controllers/Login.js
@@ -76,6 +76,9 @@ class EufyLogin extends Base_1.Base {
                 this.cloudDevices = await this.tuyaApi.getDeviceList();
                 this.cloudDevices = this.cloudDevices.map(device => ({
                     ...this.findModel(device.devId),
+                    localKey: device.localKey,
+                    productId: device.productId,
+                    ip: device.ip,
                     apiType: this.checkApiType(device.dps),
                     mqtt: false,
                     dps: device?.dps || {}

--- a/build/esm/controllers/SharedConnect.js
+++ b/build/esm/controllers/SharedConnect.js
@@ -5,18 +5,22 @@ const Base_1 = require("./Base");
 const state_constants_1 = require("../constants/state.constants");
 const devices_constants_1 = require("../constants/devices.constants");
 const utils_1 = require("../lib/utils");
+const LOCAL_NOVEL_FALLBACK_DPS = ['151', '156', '158', '159', '160', '161', '163', '177'];
 class SharedConnect extends Base_1.Base {
     novelApi = false;
     robovacData = {};
+    rawDps = {};
     debugLog;
     deviceId;
     deviceModel;
     config = {};
+    seq;
     constructor(config) {
         super();
         this.deviceId = config.deviceId;
         this.deviceModel = config.deviceModel || '';
         this.debugLog = config.debug || false;
+        this.seq = Math.floor(Date.now() % 1000);
     }
     async checkApiType(dps) {
         try {
@@ -24,7 +28,7 @@ class SharedConnect extends Base_1.Base {
                 console.log('Novel API detected');
                 this.setApiTypes(true);
             }
-            else {
+            else if (!this.novelApi) {
                 console.log('Legacy API detected');
                 this.setApiTypes(false);
             }
@@ -36,9 +40,10 @@ class SharedConnect extends Base_1.Base {
     async setApiTypes(novelApi) {
         this.novelApi = novelApi;
         this.DPSMap = this.novelApi ? this.novelDPSMap : this.legacyDPSMap;
-        this.robovacData = { ...this.DPSMap }; // Make shallow copy of DPSMap
+        this.robovacData = { ...this.DPSMap };
     }
     mapData(dps) {
+        this.rawDps = { ...this.rawDps, ...(dps || {}) };
         for (const key in dps) {
             const mappedKeys = Object.keys(this.DPSMap).filter(k => this.DPSMap[k] === key);
             if (mappedKeys.length) {
@@ -54,6 +59,33 @@ class SharedConnect extends Base_1.Base {
     async getRobovacData() {
         return this.robovacData;
     }
+    async listScenes() {
+        const raw = this.rawDps['180'] || this.robovacData?.SCENES;
+        if (typeof raw !== 'string') {
+            return [];
+        }
+        try {
+            const value = await (0, utils_1.decode)('./proto/cloud/scene.proto', 'SceneResponse', raw);
+            const infos = Array.isArray(value?.infos) ? value.infos : [];
+            return infos
+                .map((info) => ({
+                id: Number(info?.id?.value ?? 0),
+                name: String(info?.name ?? '').trim(),
+                mapId: info?.mapid ? Number(info.mapid) : undefined
+            }))
+                .filter((scene) => scene.id > 0 && scene.name);
+        }
+        catch (error) {
+            console.error(error);
+            return [];
+        }
+    }
+    supportsNamedScenes() {
+        return !!this.config?.mqtt;
+    }
+    supportsNumericRoomClean() {
+        return !!this.config?.localKey && (this.novelApi || this.canUseMappedLocalFallback());
+    }
     async getCleanSpeed() {
         if (typeof this.robovacData?.CLEAN_SPEED === 'number' || this.robovacData?.CLEAN_SPEED?.length === 1) {
             const cleanSpeeds = Object.values(state_constants_1.EUFY_CLEAN_NOVEL_CLEAN_SPEED);
@@ -64,7 +96,6 @@ class SharedConnect extends Base_1.Base {
     async getControlResponse() {
         try {
             if (this.novelApi) {
-                //BAgNEH0=
                 const value = await (0, utils_1.decode)('./proto/cloud/control.proto', 'ModeCtrlResponse', 'AhB8');
                 return value || {};
             }
@@ -166,83 +197,84 @@ class SharedConnect extends Base_1.Base {
         }
     }
     async autoClean() {
-        let value = true;
-        if (this.novelApi) {
-            value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: state_constants_1.EUFY_CLEAN_CONTROL.START_AUTO_CLEAN,
                 autoClean: {
                     cleanTimes: 1
                 }
             });
-            return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value });
         }
         await this.sendCommand({ [this.DPSMap.WORK_MODE]: state_constants_1.EUFY_CLEAN_WORK_MODE.AUTO });
         return await this.play();
     }
     async sceneClean(id) {
-        await this.stop();
-        let value = true;
-        let increment = 3; // Scene 1 is 4, Scene 2 is 5, Scene 3 is 6 etc.
-        if (this.novelApi) {
-            value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.supportsNamedScenes()) {
+            return await this.sendNovelControlCommand({
                 method: state_constants_1.EUFY_CLEAN_CONTROL.START_SCENE_CLEAN,
                 sceneClean: {
-                    sceneId: id + increment
+                    sceneId: id
                 }
             });
         }
-        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value });
+        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: true });
+    }
+    async sceneCleanSlot(slot) {
+        if (this.novelApi || this.supportsNamedScenes()) {
+            return await this.sendNovelControlCommand({
+                method: state_constants_1.EUFY_CLEAN_CONTROL.START_SCENE_CLEAN,
+                sceneClean: {
+                    sceneId: slot + 3
+                }
+            });
+        }
+        return await this.sceneClean(slot);
     }
     async play() {
         let value = true;
-        if (this.novelApi) {
-            value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: state_constants_1.EUFY_CLEAN_CONTROL.RESUME_TASK
             });
         }
         return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value });
     }
     async pause() {
-        let value = false;
-        if (this.novelApi) {
-            value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: state_constants_1.EUFY_CLEAN_CONTROL.PAUSE_TASK
             });
         }
-        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value });
+        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: false });
     }
     async stop() {
-        let value = false;
-        if (this.novelApi) {
-            value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: state_constants_1.EUFY_CLEAN_CONTROL.STOP_TASK
             });
         }
-        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value });
+        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: false });
     }
     async goHome() {
-        if (this.novelApi) {
-            const value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: state_constants_1.EUFY_CLEAN_CONTROL.START_GOHOME
             });
-            return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value });
         }
         return await this.sendCommand({ [this.DPSMap.GO_HOME]: true });
     }
     async spotClean() {
-        if (this.novelApi) {
-            const value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: state_constants_1.EUFY_CLEAN_CONTROL.START_SPOT_CLEAN
             });
-            return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value });
         }
     }
     async roomClean() {
-        if (this.novelApi) {
-            const value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseMappedLocalFallback()) {
+            return await this.sendNovelControlCommand({
                 method: state_constants_1.EUFY_CLEAN_CONTROL.START_SELECT_ROOMS_CLEAN
             });
-            return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value });
         }
         if (devices_constants_1.EUFY_CLEAN_X_SERIES.includes(this.deviceModel) || devices_constants_1.EUFY_CLEAN_E_SERIES.includes(this.deviceModel)) {
             await this.sendCommand({ [this.DPSMap.WORK_MODE]: state_constants_1.EUFY_CLEAN_WORK_MODE.SMALL_ROOM });
@@ -250,6 +282,29 @@ class SharedConnect extends Base_1.Base {
         }
         await this.sendCommand({ [this.DPSMap.WORK_MODE]: state_constants_1.EUFY_CLEAN_WORK_MODE.ROOM });
         return await this.play();
+    }
+    async cleanRooms(roomIds, cleanTimes = 1) {
+        const normalizedRoomIds = roomIds
+            .map((roomId) => Number.parseInt(String(roomId), 10))
+            .filter((roomId) => Number.isFinite(roomId) && roomId > 0);
+        if (!normalizedRoomIds.length) {
+            throw new Error('Please provide at least one valid room ID.');
+        }
+        if (this.novelApi || this.canUseMappedLocalFallback()) {
+            const mapId = Number(this.config?.mapId || 0);
+            return await this.sendNovelControlCommand({
+                method: state_constants_1.EUFY_CLEAN_CONTROL.START_SELECT_ROOMS_CLEAN,
+                selectRoomsClean: {
+                    rooms: normalizedRoomIds.map((id, index) => ({
+                        id,
+                        order: index + 1
+                    })),
+                    cleanTimes: cleanTimes > 0 ? cleanTimes : 1,
+                    ...(mapId > 0 ? { mapId } : {})
+                }
+            });
+        }
+        return await this.roomClean();
     }
     async setCleanParam(config) {
         if (!this.novelApi)
@@ -279,6 +334,30 @@ class SharedConnect extends Base_1.Base {
     }
     async sendCommand(data) {
         throw new Error('Method not implemented.');
+    }
+    nextSeq() {
+        this.seq = (this.seq % 65535) + 1;
+        return this.seq;
+    }
+    hasNovelLocalControlSignals() {
+        return !!this.config?.localKey && Object.keys(this.rawDps).some((key) => LOCAL_NOVEL_FALLBACK_DPS.includes(key));
+    }
+    canUseLocalNovelControlFallback() {
+        return !this.novelApi && this.hasNovelLocalControlSignals();
+    }
+    canUseMappedLocalFallback() {
+        const mapId = Number(this.config?.mapId || 0);
+        return this.canUseLocalNovelControlFallback() && mapId > 0;
+    }
+    getNovelControlDp() {
+        return this.novelApi ? this.DPSMap.PLAY_PAUSE : this.novelDPSMap.PLAY_PAUSE;
+    }
+    async sendNovelControlCommand(command) {
+        const value = await (0, utils_1.encode)('proto/cloud/control.proto', 'ModeCtrlRequest', {
+            seq: this.nextSeq(),
+            ...command
+        });
+        return await this.sendCommand({ [this.getNovelControlDp()]: value });
     }
 }
 exports.SharedConnect = SharedConnect;

--- a/build/esm/index.js
+++ b/build/esm/index.js
@@ -56,8 +56,7 @@ class EufyClean {
         return [...this.eufyCleanApi.cloudDevices, ...this.eufyCleanApi.mqttDevices];
     }
     async initDevice(deviceConfig) {
-        if ('localKey' in deviceConfig && 'ip' in deviceConfig && deviceConfig.localKey) {
-            console.log('LocalConnect is deprecated, use CloudConnect instead');
+        if ('localKey' in deviceConfig && deviceConfig.localKey) {
             return new LocalConnect_1.LocalConnect(deviceConfig);
         }
         // Local connection doesn't require this check

--- a/build/esm/lib/utils.js
+++ b/build/esm/lib/utils.js
@@ -37,8 +37,8 @@ exports.decode = decode;
 const encode = async function (proto, type, object) {
     const root = await (0, exports.getProtoFile)(proto);
     const protoLookupType = root.lookupType(type);
-    // Create a new message from the object
-    const message = protoLookupType.create(object);
+    // Convert plain objects so enum/string fields are mapped correctly.
+    const message = protoLookupType.fromObject(object);
     // Encode the message to a buffer using encodeDelimited
     const buffer = protoLookupType.encodeDelimited(message).finish();
     // Convert the buffer to a base64 string

--- a/src/controllers/LocalConnect.ts
+++ b/src/controllers/LocalConnect.ts
@@ -1,17 +1,19 @@
-// Communication with the Local Tuya API
-// This is only supported for "old" devices like the RoboVac G30
-
-// As of july 2024 this is not used in the main codebase, but it's here for reference
 import { sleep } from '../lib/utils';
 import { SharedConnect } from './SharedConnect';
 import TuyAPI from 'tuyapi';
 
+const PROBE_DPS = [
+    2, 5, 15, 101, 103, 104, 106, 109, 110, 111, 116, 117, 124, 125, 126, 135, 142,
+    151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163,
+    164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180
+];
+
 export class LocalConnect extends SharedConnect {
     public api: any;
     private didCheckApiType: boolean;
-    private connected: boolean
+    private connected: boolean;
 
-    constructor(config: { deviceId: string, localKey?: string, ip?: string, debug?: boolean, deviceModel?: string }) {
+    constructor(config: { deviceId: string, localKey?: string, ip?: string, version?: string, mapId?: number, findTimeoutSeconds?: number, debug?: boolean, deviceModel?: string }) {
         super(config);
 
         this.deviceId = config.deviceId;
@@ -19,6 +21,7 @@ export class LocalConnect extends SharedConnect {
         this.config = config;
         this.debugLog = config.debug || false;
         this.didCheckApiType = false;
+        this.connected = false;
     }
 
     async setupApi(config) {
@@ -28,7 +31,8 @@ export class LocalConnect extends SharedConnect {
                 key: config.localKey,
                 ip: config.ip,
                 port: 6668,
-                version: '3.3'
+                version: config.version || '3.3',
+                issueRefreshOnConnect: true
             }
         );
 
@@ -56,30 +60,24 @@ export class LocalConnect extends SharedConnect {
     }
 
     async onUpdate(dps) {
-        if(!this.didCheckApiType) {
+        if (!this.didCheckApiType) {
             this.didCheckApiType = true;
             await this.checkApiType(dps);
         }
-        
+
         this.mapData(dps)
     }
 
     async connect() {
         if (!this.connected) {
             await this.setupApi(this.config);
-            await sleep(2000);
+            await sleep(500);
 
             console.log('Connecting...');
-
-            await this.api.connect().catch(error => {
-                console.log(error)
-                console.error(
-                    `Failed to connect to device please close the app or check your network. Please allow port 6668 via TCP from the device IP. ${error}`,
-                );
-            });
+            await this.connectWithFallback();
         }
 
-        await this.api.refresh({ schema: true });
+        await this.refreshDeviceState();
 
         setTimeout(() => {
             this.formatStatus();
@@ -88,12 +86,14 @@ export class LocalConnect extends SharedConnect {
 
     async disconnect() {
         console.log('Disconnecting...');
-        await this.api.disconnect();
+        if (this.api) {
+            await this.api.disconnect();
+        }
     }
 
     async updateDevice() {
         try {
-            await this.api?.refresh({ schema: true });
+            await this.refreshDeviceState();
         } catch (error) {
             console.log(error)
         }
@@ -108,5 +108,62 @@ export class LocalConnect extends SharedConnect {
             multiple: true,
             data: data
         });
+    }
+
+    getResolvedIp(): string | undefined {
+        return this.api?.device?.ip || this.config?.ip;
+    }
+
+    private async connectWithFallback() {
+        try {
+            if (!this.config.ip) {
+                await this.findDevice();
+            }
+
+            await this.api.connect();
+            this.config.ip = this.getResolvedIp() || this.config.ip;
+        } catch (error) {
+            if (!this.config.ip) {
+                throw error;
+            }
+
+            console.warn('Direct local connection failed, retrying with discovery.', error);
+            this.connected = false;
+            await this.findDevice(true);
+            await this.api.connect();
+            this.config.ip = this.getResolvedIp() || this.config.ip;
+        }
+    }
+
+    private async findDevice(force = false) {
+        if (force) {
+            this.api.device && (this.api.device.ip = undefined);
+            this.config.ip = undefined;
+        }
+
+        const foundDevice = await this.api.find({
+            timeout: this.config.findTimeoutSeconds || 10
+        });
+
+        const resolvedIp = foundDevice?.ip || this.api?.device?.ip;
+        if (resolvedIp) {
+            this.config.ip = resolvedIp;
+        }
+    }
+
+    private async refreshDeviceState() {
+        const basePayload = await this.api?.get({ schema: true }).catch(() => undefined);
+        if (basePayload?.dps) {
+            await this.onUpdate(basePayload.dps);
+        }
+
+        const refreshPayload = await this.api?.refresh({
+            schema: true,
+            requestedDPS: PROBE_DPS
+        }).catch(() => undefined);
+
+        if (refreshPayload?.dps) {
+            await this.onUpdate(refreshPayload.dps);
+        }
     }
 }

--- a/src/controllers/Login.ts
+++ b/src/controllers/Login.ts
@@ -84,6 +84,9 @@ export class EufyLogin extends Base {
                 this.cloudDevices = await this.tuyaApi.getDeviceList();
                 this.cloudDevices = this.cloudDevices.map(device => ({
                     ...this.findModel(device.devId),
+                    localKey: device.localKey,
+                    productId: device.productId,
+                    ip: device.ip,
                     apiType: this.checkApiType(device.dps),
                     mqtt: false,
                     dps: device?.dps || {}

--- a/src/controllers/SharedConnect.ts
+++ b/src/controllers/SharedConnect.ts
@@ -3,13 +3,17 @@ import { EUFY_CLEAN_WORK_MODE, EUFY_CLEAN_NOVEL_CLEAN_SPEED, EUFY_CLEAN_CONTROL 
 import { EUFY_CLEAN_X_SERIES, EUFY_CLEAN_E_SERIES } from "../constants/devices.constants";
 import { decode, getMultiData, getProtoFile, encode } from '../lib/utils';
 
+const LOCAL_NOVEL_FALLBACK_DPS = ['151', '156', '158', '159', '160', '161', '163', '177'];
+
 export class SharedConnect extends Base {
     public novelApi: boolean = false;
     public robovacData: any = {};
+    public rawDps: Record<string, any> = {};
     public debugLog: boolean;
     public deviceId: string;
     public deviceModel: string;
-    public config = {};
+    public config: any = {};
+    private seq: number;
 
     constructor(config: { deviceId: string, deviceModel?: string, debug?: boolean }) {
         super();
@@ -17,6 +21,7 @@ export class SharedConnect extends Base {
         this.deviceId = config.deviceId;
         this.deviceModel = config.deviceModel || '';
         this.debugLog = config.debug || false;
+        this.seq = Math.floor(Date.now() % 1000);
     }
 
     public async checkApiType(dps) {
@@ -24,7 +29,7 @@ export class SharedConnect extends Base {
             if (!this.novelApi && Object.values(this.novelDPSMap).some(k => k in dps)) {
                 console.log('Novel API detected');
                 this.setApiTypes(true);
-            } else {
+            } else if (!this.novelApi) {
                 console.log('Legacy API detected');
                 this.setApiTypes(false);
             }
@@ -38,11 +43,13 @@ export class SharedConnect extends Base {
         this.novelApi = novelApi;
 
         this.DPSMap = this.novelApi ? this.novelDPSMap : this.legacyDPSMap;
-        this.robovacData = { ...this.DPSMap }; // Make shallow copy of DPSMap
+        this.robovacData = { ...this.DPSMap };
     }
 
 
     public mapData(dps: any) {
+        this.rawDps = { ...this.rawDps, ...(dps || {}) };
+
         for (const key in dps) {
             const mappedKeys = Object.keys(this.DPSMap).filter(k => this.DPSMap[k] === key);
 
@@ -62,6 +69,36 @@ export class SharedConnect extends Base {
         return this.robovacData;
     }
 
+    public async listScenes(): Promise<Array<{ id: number; name: string; mapId?: number }>> {
+        const raw = this.rawDps['180'] || this.robovacData?.SCENES;
+        if (typeof raw !== 'string') {
+            return [];
+        }
+
+        try {
+            const value = await decode('./proto/cloud/scene.proto', 'SceneResponse', raw);
+            const infos = Array.isArray(value?.infos) ? value.infos : [];
+
+            return infos
+                .map((info: any) => ({
+                    id: Number(info?.id?.value ?? 0),
+                    name: String(info?.name ?? '').trim(),
+                    mapId: info?.mapid ? Number(info.mapid) : undefined
+                }))
+                .filter((scene) => scene.id > 0 && scene.name);
+        } catch (error) {
+            console.error(error);
+            return [];
+        }
+    }
+
+    public supportsNamedScenes(): boolean {
+        return !!this.config?.mqtt;
+    }
+
+    public supportsNumericRoomClean(): boolean {
+        return !!this.config?.localKey && (this.novelApi || this.canUseMappedLocalFallback());
+    }
 
     async getCleanSpeed() {
         if (typeof this.robovacData?.CLEAN_SPEED === 'number' || this.robovacData?.CLEAN_SPEED?.length === 1) {
@@ -76,7 +113,6 @@ export class SharedConnect extends Base {
     async getControlResponse() {
         try {
             if (this.novelApi) {
-                //BAgNEH0=
                 const value = await decode('./proto/cloud/control.proto', 'ModeCtrlResponse', 'AhB8');
                 return value || {};
             }
@@ -195,17 +231,13 @@ export class SharedConnect extends Base {
     }
 
     async autoClean() {
-        let value = true;
-
-        if (this.novelApi) {
-            value = await encode('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: EUFY_CLEAN_CONTROL.START_AUTO_CLEAN,
                 autoClean: {
                     cleanTimes: 1
                 }
-            })
-
-            return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value })
+            });
         }
 
         await this.sendCommand({ [this.DPSMap.WORK_MODE]: EUFY_CLEAN_WORK_MODE.AUTO })
@@ -213,88 +245,86 @@ export class SharedConnect extends Base {
     }
 
     async sceneClean(id: number) {
-        await this.stop();
-
-        let value = true;
-        let increment = 3; // Scene 1 is 4, Scene 2 is 5, Scene 3 is 6 etc.
-
-        if (this.novelApi) {
-            value = await encode('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.supportsNamedScenes()) {
+            return await this.sendNovelControlCommand({
                 method: EUFY_CLEAN_CONTROL.START_SCENE_CLEAN,
                 sceneClean: {
-                    sceneId: id + increment
+                    sceneId: id
                 }
-            })
+            });
         }
 
-        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value })
+        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: true });
+    }
+
+    async sceneCleanSlot(slot: number) {
+        if (this.novelApi || this.supportsNamedScenes()) {
+            return await this.sendNovelControlCommand({
+                method: EUFY_CLEAN_CONTROL.START_SCENE_CLEAN,
+                sceneClean: {
+                    sceneId: slot + 3
+                }
+            });
+        }
+
+        return await this.sceneClean(slot);
     }
 
     async play() {
         let value = true;
 
-        if (this.novelApi) {
-            value = await encode('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: EUFY_CLEAN_CONTROL.RESUME_TASK
-            })
+            });
         }
 
         return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value })
     }
 
     async pause() {
-        let value = false
-
-        if (this.novelApi) {
-            value = await encode('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: EUFY_CLEAN_CONTROL.PAUSE_TASK
-            })
+            });
         }
 
-        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value })
+        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: false })
     }
 
     async stop() {
-        let value = false
-
-        if (this.novelApi) {
-            value = await encode('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: EUFY_CLEAN_CONTROL.STOP_TASK
-            })
+            });
         }
 
-        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value })
+        return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: false })
     }
 
     async goHome() {
-        if (this.novelApi) {
-            const value = await encode('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: EUFY_CLEAN_CONTROL.START_GOHOME
             });
-
-            return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value })
         }
 
         return await this.sendCommand({ [this.DPSMap.GO_HOME]: true })
     }
 
     async spotClean() {
-        if (this.novelApi) {
-            const value = await encode('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseLocalNovelControlFallback()) {
+            return await this.sendNovelControlCommand({
                 method: EUFY_CLEAN_CONTROL.START_SPOT_CLEAN
             });
-
-            return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value })
         }
     }
 
     async roomClean() {
-        if (this.novelApi) {
-            const value = await encode('proto/cloud/control.proto', 'ModeCtrlRequest', {
+        if (this.novelApi || this.canUseMappedLocalFallback()) {
+            return await this.sendNovelControlCommand({
                 method: EUFY_CLEAN_CONTROL.START_SELECT_ROOMS_CLEAN
             });
-
-            return await this.sendCommand({ [this.DPSMap.PLAY_PAUSE]: value })
         }
 
 
@@ -305,6 +335,34 @@ export class SharedConnect extends Base {
 
         await this.sendCommand({ [this.DPSMap.WORK_MODE]: EUFY_CLEAN_WORK_MODE.ROOM })
         return await this.play();
+    }
+
+    async cleanRooms(roomIds: number[], cleanTimes = 1) {
+        const normalizedRoomIds = roomIds
+            .map((roomId) => Number.parseInt(String(roomId), 10))
+            .filter((roomId) => Number.isFinite(roomId) && roomId > 0);
+
+        if (!normalizedRoomIds.length) {
+            throw new Error('Please provide at least one valid room ID.');
+        }
+
+        if (this.novelApi || this.canUseMappedLocalFallback()) {
+            const mapId = Number(this.config?.mapId || 0);
+
+            return await this.sendNovelControlCommand({
+                method: EUFY_CLEAN_CONTROL.START_SELECT_ROOMS_CLEAN,
+                selectRoomsClean: {
+                    rooms: normalizedRoomIds.map((id, index) => ({
+                        id,
+                        order: index + 1
+                    })),
+                    cleanTimes: cleanTimes > 0 ? cleanTimes : 1,
+                    ...(mapId > 0 ? { mapId } : {})
+                }
+            });
+        }
+
+        return await this.roomClean();
     }
 
     async setCleanParam(config: { cleanType?: 'SWEEP_AND_MOP' | 'SWEEP_ONLY' | 'MOP_ONLY', mopMode?: 'HIGH' | 'MEDIUM' | 'LOW', cleanExtent?: 'NORMAL' | 'NARROW' | 'QUICK' }) {
@@ -342,5 +400,36 @@ export class SharedConnect extends Base {
 
     public async sendCommand(data: { [key: string]: string | number | boolean }) {
         throw new Error('Method not implemented.');
+    }
+
+    private nextSeq(): number {
+        this.seq = (this.seq % 65535) + 1;
+        return this.seq;
+    }
+
+    private hasNovelLocalControlSignals(): boolean {
+        return !!this.config?.localKey && Object.keys(this.rawDps).some((key) => LOCAL_NOVEL_FALLBACK_DPS.includes(key));
+    }
+
+    private canUseLocalNovelControlFallback(): boolean {
+        return !this.novelApi && this.hasNovelLocalControlSignals();
+    }
+
+    private canUseMappedLocalFallback(): boolean {
+        const mapId = Number(this.config?.mapId || 0);
+        return this.canUseLocalNovelControlFallback() && mapId > 0;
+    }
+
+    private getNovelControlDp(): string {
+        return this.novelApi ? this.DPSMap.PLAY_PAUSE : this.novelDPSMap.PLAY_PAUSE;
+    }
+
+    private async sendNovelControlCommand(command: Record<string, any>) {
+        const value = await encode('proto/cloud/control.proto', 'ModeCtrlRequest', {
+            seq: this.nextSeq(),
+            ...command
+        });
+
+        return await this.sendCommand({ [this.getNovelControlDp()]: value });
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,8 @@ export class EufyClean {
         return [...this.eufyCleanApi.cloudDevices, ...this.eufyCleanApi.mqttDevices]
     }
 
-    public async initDevice(deviceConfig: { deviceId: string, localKey?: string, ip?: string, debug?: boolean }): Promise<CloudConnect | MqttConnect | LocalConnect | null> {
-        if ('localKey' in deviceConfig && 'ip' in deviceConfig && deviceConfig.localKey) {
-            console.log('LocalConnect is deprecated, use CloudConnect instead');
+    public async initDevice(deviceConfig: { deviceId: string, localKey?: string, ip?: string, version?: string, mapId?: number, findTimeoutSeconds?: number, debug?: boolean }): Promise<CloudConnect | MqttConnect | LocalConnect | null> {
+        if ('localKey' in deviceConfig && deviceConfig.localKey) {
             return new LocalConnect(deviceConfig);
         }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -43,8 +43,8 @@ export const encode = async function (proto, type, object) {
 
     const protoLookupType = root.lookupType(type);
 
-    // Create a new message from the object
-    const message = protoLookupType.create(object);
+    // Convert plain objects so enum/string fields are mapped correctly.
+    const message = protoLookupType.fromObject(object);
 
 
     // Encode the message to a buffer using encodeDelimited


### PR DESCRIPTION
## Summary

This PR adds the library-side support needed by the Homey app to control newer Eufy MQTT vacuums using their real saved scene metadata, while preserving the existing slot-based scene behavior for older Homey flows.

It also restores local-key discovery and adds numeric room-clean support for local Tuya-capable mapped vacuums.

## MQTT scene problem and solution

The Homey app previously exposed a static `Scene 1` through `Scene 10` card. That works only if a device interprets those slots the way the old card expects. On newer MQTT devices such as the Omni C20 (`T2280`), saved scenes are exposed by the robot/app as real scene records with large scene IDs and names, for example:

- `1767280292` -> `Deep Clean`
- `1772188900` -> `Deep Clean and Mop`

The old behavior cannot reliably start those saved scenes because it does not know the actual scene IDs. It also used slot-style translation (`slot + 3`) rather than the real MQTT scene ID.

This PR solves that by adding first-class scene metadata support:

- `listScenes()` decodes DPS `180` as `SceneResponse` and returns `{ id, name, mapId }` records.
- `sceneClean(sceneId)` now sends the exact selected scene ID in `START_SCENE_CLEAN`.
- `sceneCleanSlot(slot)` preserves the old slot-based behavior by keeping the `slot + 3` translation for existing `Scene 1..10` flows.
- The shared protobuf encoder now uses `fromObject(...)` before `encodeDelimited(...)`, which is required for enum fields such as `START_SCENE_CLEAN` and `START_SELECT_ROOMS_CLEAN` to encode correctly.

So the new Homey flow can show a live scene autocomplete list for MQTT devices, while old slot-based flows keep working unchanged.

## Local Tuya room cleaning

For local Tuya-capable mapped vacuums, this PR also adds:

- restored local key propagation from discovery
- local connection config for `localKey`, optional `ip`, protocol version, map ID, timeout, and debug flag
- `cleanRooms(roomIds, cleanTimes)` for numeric room cleaning
- protobuf room-clean commands on DPS `152` for novel/mapped local devices

This allows the Homey app to offer a numeric `Clean room` action for local-key devices without requiring room-name discovery.

## Notes

The Homey app PR should depend on this library change so it can call `listScenes()`, `sceneClean(sceneId)`, `sceneCleanSlot(slot)`, and `cleanRooms(roomIds, cleanTimes)`.
